### PR TITLE
Cross-process tracing

### DIFF
--- a/lib/faraday/honeycomb/middleware.rb
+++ b/lib/faraday/honeycomb/middleware.rb
@@ -90,10 +90,17 @@ module Faraday
         span_id = SecureRandom.uuid
         event.add_field 'trace.span_id', span_id
 
+        add_trace_context_header(env, trace_id, span_id) if trace_id
+
         ::Honeycomb.with_span_id(span_id) do |parent_span_id|
           event.add_field 'trace.parent_id', parent_span_id
           yield
         end
+      end
+
+      def add_trace_context_header(env, trace_id, span_id)
+        encoded_context = ::Honeycomb.encode_trace_context(trace_id, span_id, hypothetical_example_of_context: 'TODO')
+        env.request_headers['X-Honeycomb-Trace'] = encoded_context
       end
     end
   end

--- a/lib/faraday/honeycomb/middleware.rb
+++ b/lib/faraday/honeycomb/middleware.rb
@@ -25,6 +25,7 @@ module Faraday
         end
         @builder = honeycomb.builder.
           add(
+            'type' => 'http_client',
             'meta.package' => 'faraday',
             'meta.package_version' => Faraday::VERSION,
           )
@@ -65,8 +66,10 @@ module Faraday
       end
 
       def add_request_fields(event, env)
+        loud_method = loud_method(env)
         event.add(
-          'request.method' => loud_method(env),
+          'name' => "#{loud_method} #{env.url.host}#{env.url.path}",
+          'request.method' => loud_method,
           'request.protocol' => env.url.scheme,
           'request.host' => env.url.host,
           'request.path' => env.url.path,

--- a/lib/faraday/honeycomb/middleware.rb
+++ b/lib/faraday/honeycomb/middleware.rb
@@ -85,19 +85,38 @@ module Faraday
       end
 
       def with_tracing_if_available(event, env)
-        return yield unless defined?(::Honeycomb::Beeline::VERSION)
+        # return if we are not using the ruby beeline
+        return yield unless defined?(::Honeycomb)
 
-        name = "#{loud_method(env)} #{env.url.host}#{env.url.path}"
+        # beeline version <= 0.5.0
+        if ::Honeycomb.respond_to? :trace_id
+          trace_id = ::Honeycomb.trace_id
+          event.add_field 'trace.trace_id', trace_id if trace_id
+          span_id = SecureRandom.uuid
+          event.add_field 'trace.span_id', span_id
 
-        ::Honeycomb.span_for_existing_event event, name: name, type: 'http_client' do |span_id, trace_id|
-          add_trace_context_header(env, trace_id, span_id)
+          ::Honeycomb.with_span_id(span_id) do |parent_span_id|
+            event.add_field 'trace.parent_id', parent_span_id
+            yield
+          end
+        # beeline version > 0.5.0
+        elsif ::Honeycomb.respond_to? :span_for_existing_event
+          ::Honeycomb.span_for_existing_event event, name: nil, type: 'http_client' do |span_id, trace_id|
+            add_trace_context_header(env, trace_id, span_id)
+            yield
+          end
+        # fallback if we don't detect any known beeline tracing methods
+        else
           yield
         end
       end
 
       def add_trace_context_header(env, trace_id, span_id)
-        encoded_context = ::Honeycomb.encode_trace_context(trace_id, span_id, **::Honeycomb.active_trace_context)
-        env.request_headers['X-Honeycomb-Trace'] = encoded_context
+        # beeline version > 0.5.0
+        if ::Honeycomb.respond_to? :encode_trace_context
+          encoded_context = ::Honeycomb.encode_trace_context(trace_id, span_id, **::Honeycomb.active_trace_context)
+          env.request_headers['X-Honeycomb-Trace'] = encoded_context
+        end
       end
     end
   end

--- a/spec/middleware/middleware_spec.rb
+++ b/spec/middleware/middleware_spec.rb
@@ -35,13 +35,6 @@ RSpec.describe Faraday::Honeycomb::Middleware do
       expect(response.status).to eq(200)
     end
 
-    it 'sends an http_client event' do
-      expect(emitted_event.data).to include(
-        'type' => 'http_client',
-        'name' => 'GET example.com/',
-      )
-    end
-
     it 'includes basic request and response fields' do
       expect(emitted_event.data).to include(
         'request.method' => 'GET',

--- a/spec/middleware/middleware_spec.rb
+++ b/spec/middleware/middleware_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe Faraday::Honeycomb::Middleware do
       expect(response.status).to eq(200)
     end
 
+    it 'sends an http_client event' do
+      expect(emitted_event.data).to include(
+        'type' => 'http_client',
+        'name' => 'GET example.com/',
+      )
+    end
+
     it 'includes basic request and response fields' do
       expect(emitted_event.data).to include(
         'request.method' => 'GET',


### PR DESCRIPTION
This adds support for cross-process tracing, compatible with the other Beelines, propagating trace context by setting the `X-Honeycomb-Trace` request header in the format documented [in the Node Beeline source](https://github.com/honeycombio/beeline-nodejs/blob/6fe61aafce61c8106a1c9dacbe2f99210e3698ae/lib/propagation.js#L12-L25).

It depends on the new unreleased tracing API in https://github.com/honeycombio/beeline-ruby/pull/4.