### PR TITLE
Include all of the default stack

### DIFF
--- a/lib/faraday-honeycomb/auto_install.rb
+++ b/lib/faraday-honeycomb/auto_install.rb
@@ -30,6 +30,7 @@ module Faraday
                 proc do |b|
                   logger.debug "Adding Faraday::Honeycomb::Middleware in #{self}.new" if logger
                   b.use :honeycomb, client: honeycomb_client, logger: logger
+                  b.request :url_encoded
                   b.adapter Faraday.default_adapter
                 end
               end


### PR DESCRIPTION
By default both of these are added by faraday https://github.com/lostisland/faraday/blob/master/lib/faraday/rack_builder.rb#L58.

Without this when you try to perform a request with a body without setting up your own stack faraday won't know how to handle a non string body.
