### PR TITLE
Handle builder being provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+script: rake && rake auto_install_spec
 deploy:
   provider: rubygems
   api_key:

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,12 @@ require 'yard'
 
 YARD::Rake::YardocTask.new(:doc)
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = "--tag ~auto_install"
+end
+
+RSpec::Core::RakeTask.new(:auto_install_spec) do |t|
+  t.rspec_opts = "--tag auto_install"
+end
 
 task default: :spec

--- a/spec/auto_install_spec.rb
+++ b/spec/auto_install_spec.rb
@@ -1,0 +1,42 @@
+require 'faraday'
+require 'faraday-honeycomb'
+require 'faraday-honeycomb/auto_install'
+
+RSpec.describe Faraday::Honeycomb::AutoInstall, auto_install: true do
+  before(:all) do
+    Faraday::Honeycomb::AutoInstall.auto_install!(honeycomb_client: Libhoney::TestClient.new)
+  end
+
+  it "standard usage with no block works" do
+    f = Faraday.new("http://honeycomb.io")
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Request::UrlEncoded, Faraday::Adapter::NetHttp])
+  end
+
+  it "providing a builder with string key works" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.adapter Faraday.default_adapter
+    end
+    f = Faraday.new("builder" => stack)
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Adapter::NetHttp])
+  end
+
+  it "providing a builder with symbol key works" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.adapter Faraday.default_adapter
+    end
+    f = Faraday.new(builder: stack)
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Adapter::NetHttp])
+  end
+
+
+  it "providing a builder and a block works" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.response :logger
+    end
+    f = Faraday.new(builder: stack) do |faraday|
+      faraday.request  :url_encoded
+      faraday.adapter Faraday.default_adapter
+    end
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Response::Logger, Faraday::Request::UrlEncoded, Faraday::Adapter::NetHttp])
+  end
+end


### PR DESCRIPTION
Handle a builder being provided to faraday and test that the middleware is setup correctly in all cases.

Related:

- https://github.com/honeycombio/faraday-honeycomb/issues/6
- https://github.com/honeycombio/beeline-ruby/issues/15