### PR TITLE
Do not autoinstall middleware if it's already present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Gemfile.lock
 spec/examples.txt
 .yardoc
 doc
+.byebug_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+script: rake && rake auto_install_spec
 deploy:
   provider: rubygems
   api_key:

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,12 @@ require 'yard'
 
 YARD::Rake::YardocTask.new(:doc)
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = "--tag ~auto_install"
+end
+
+RSpec::Core::RakeTask.new(:auto_install_spec) do |t|
+  t.rspec_opts = "--tag auto_install"
+end
 
 task default: :spec

--- a/faraday-honeycomb.gemspec
+++ b/faraday-honeycomb.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'yard'
+  gem.add_development_dependency 'byebug'
+  gem.add_development_dependency 'pry'
 
   gem.files = Dir[*%w(
       lib/**/*

--- a/lib/faraday-honeycomb/auto_install.rb
+++ b/lib/faraday-honeycomb/auto_install.rb
@@ -14,38 +14,74 @@ module Faraday
           false
         end
 
+        def ensure_middleware_in_builder!(builder, client, logger)
+          if builder.handlers.any? { |m| m.klass == ::Faraday::Honeycomb::Middleware }
+            logger.debug "Faraday::Honeycomb::Middleware already exists in Faraday middleware" if logger
+            return
+          end
+
+          # In faraday < 1.0 the adapter is added directly to handlers, so we
+          # need to find it in the stack and insert honeycomb's middleware
+          # before it
+          #
+          # In faraday >= 1.0 the adapter will never be in the list of
+          # handlers, and will _always_ be the last thing called in the
+          # middleware stack, so we need to handle it not being present.
+          # https://github.com/lostisland/faraday/pull/750
+          index_of_first_adapter = (builder.handlers || [])
+            .find_index { |h| h.klass.ancestors.include? Faraday::Adapter }
+
+          if index_of_first_adapter
+            logger.debug "Adding Faraday::Honeycomb::Middleware before adapter" if logger
+            builder.insert_before(
+              index_of_first_adapter,
+              Faraday::Honeycomb::Middleware,
+              client: client, logger: logger
+            )
+          else
+            logger.debug "Appending Faraday::Honeycomb::Middleware to stack" if logger
+            builder.use Faraday::Honeycomb::Middleware, client: client, logger: logger
+          end
+        end
+
         def auto_install!(honeycomb_client:, logger: nil)
           require 'faraday'
           require 'faraday-honeycomb'
 
           Faraday::Connection.extend(Module.new do
             define_method :new do |*args, &orig_block|
-              if original_args = args.first
-                if original_args.respond_to? :key
-                  builder = original_args["builder"] || original_args[:builder]
+              # If there are two arguments the first argument might be an
+              # options hash, or a URL. The last argument in the array is
+              # always an instance of `ConnectionOptions`.
+              options = args.reduce({}) do |out, arg|
+                out.merge!(arg.to_hash) if arg.respond_to? :to_hash
+                out
+              end
+
+              builder = options["builder"] || options[:builder]
+
+              if !builder
+                # This is the configuration that would be applied if someone
+                # created faraday without a config block/builder. We need to specify it
+                # here because our monkeypatch causes a block to _always_ be
+                # passed to Faraday
+                # https://github.com/lostisland/faraday/blob/v0.15.4/lib/faraday/rack_builder.rb#L56-L60
+                orig_block ||= proc do |c|
+                  c.request :url_encoded
+                  c.adapter Faraday.default_adapter
                 end
               end
-              case
-              when builder
-                logger.debug "Adding Faraday::Honeycomb::Middleware in #{self}.new{}" if logger
-                builder.insert(0, ::Faraday::Honeycomb::Middleware, client: honeycomb_client, logger: logger)
-                super(*args, &orig_block)
-              when orig_block
-                block = proc do |b|
-                  logger.debug "Adding Faraday::Honeycomb::Middleware in #{self}.new{}" if logger
-                  b.use :honeycomb, client: honeycomb_client, logger: logger
-                  orig_block.call(b)
-                end
-                super(*args, &block)
-              else
-                block = proc do |b|
-                  logger.debug "Adding Faraday::Honeycomb::Middleware in #{self}.new" if logger
-                  b.use :honeycomb, client: honeycomb_client, logger: logger
-                  b.request :url_encoded
-                  b.adapter Faraday.default_adapter
-                end
+
+              # Always add honeycomb middleware after the middleware stack has
+              # been resolved by the original block/any defaults that are
+              # applied by Faraday
+              block = proc do |b|
+                orig_block.call(b) if orig_block
+
+                Honeycomb::AutoInstall.ensure_middleware_in_builder!(b.builder, honeycomb_client, logger)
+              end
+
               super(*args, &block)
-              end
             end
           end)
         end

--- a/spec/auto_install_spec.rb
+++ b/spec/auto_install_spec.rb
@@ -1,0 +1,42 @@
+require 'faraday'
+require 'faraday-honeycomb'
+require 'faraday-honeycomb/auto_install'
+
+RSpec.describe Faraday::Honeycomb::AutoInstall, auto_install: true do
+  before(:all) do
+    Faraday::Honeycomb::AutoInstall.auto_install!(honeycomb_client: Libhoney::TestClient.new)
+  end
+
+  it "standard usage with no block works" do
+    f = Faraday.new("http://honeycomb.io")
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Request::UrlEncoded, Faraday::Adapter::NetHttp])
+  end
+
+  it "providing a builder with string key works" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.adapter Faraday.default_adapter
+    end
+    f = Faraday.new("builder" => stack)
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Adapter::NetHttp])
+  end
+
+  it "providing a builder with symbol key works" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.adapter Faraday.default_adapter
+    end
+    f = Faraday.new(builder: stack)
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Adapter::NetHttp])
+  end
+
+
+  it "providing a builder and a block works" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.response :logger
+    end
+    f = Faraday.new(builder: stack) do |faraday|
+      faraday.request  :url_encoded
+      faraday.adapter Faraday.default_adapter
+    end
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Response::Logger, Faraday::Request::UrlEncoded, Faraday::Adapter::NetHttp])
+  end
+end

--- a/spec/auto_install_spec.rb
+++ b/spec/auto_install_spec.rb
@@ -9,25 +9,83 @@ RSpec.describe Faraday::Honeycomb::AutoInstall, auto_install: true do
 
   it "standard usage with no block works" do
     f = Faraday.new("http://honeycomb.io")
-    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Request::UrlEncoded, Faraday::Adapter::NetHttp])
+    expect(f.builder.handlers).to eq([
+      Faraday::Request::UrlEncoded,
+      Faraday::Honeycomb::Middleware,
+      Faraday::Adapter::NetHttp
+    ])
   end
 
   it "providing a builder with string key works" do
     stack = Faraday::RackBuilder.new do |builder|
+      builder.request :retry
       builder.adapter Faraday.default_adapter
     end
     f = Faraday.new("builder" => stack)
-    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Adapter::NetHttp])
+
+    expect(f.builder.handlers).to eq([
+      Faraday::Request::Retry,
+      Faraday::Honeycomb::Middleware,
+      Faraday::Adapter::NetHttp
+    ])
   end
 
   it "providing a builder with symbol key works" do
     stack = Faraday::RackBuilder.new do |builder|
+      builder.request :retry
       builder.adapter Faraday.default_adapter
     end
     f = Faraday.new(builder: stack)
-    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Adapter::NetHttp])
+
+    expect(f.builder.handlers).to eq([
+      Faraday::Request::Retry,
+      Faraday::Honeycomb::Middleware,
+      Faraday::Adapter::NetHttp
+    ])
   end
 
+  it "providing a builder that only has an adapter works" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.adapter Faraday.default_adapter
+    end
+    f = Faraday.new(builder: stack)
+
+    expect(f.builder.handlers).to eq([
+      Faraday::Honeycomb::Middleware,
+      Faraday::Adapter::NetHttp
+    ])
+  end
+
+  it "providing a builder AND url works" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.request :retry
+      builder.adapter Faraday.default_adapter
+    end
+    f = Faraday.new("https://example.com", builder: stack)
+
+    expect(f.builder.handlers).to eq([
+      Faraday::Request::Retry,
+      Faraday::Honeycomb::Middleware,
+      Faraday::Adapter::NetHttp
+    ])
+  end
+
+  it "does not attempt to add honeycomb middleware if it already exists in the passed builder" do
+    stack = Faraday::RackBuilder.new do |builder|
+      builder.adapter Faraday.default_adapter
+    end
+    f = Faraday.new(builder: stack)
+    # force the builder to lock the middleware stack
+    f.builder.app
+
+    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Adapter::NetHttp])
+
+    f2 = Faraday.new(builder: stack)
+    # force the builder to lock the middleware stack
+    f2.builder.app
+
+    expect(f2.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Adapter::NetHttp])
+  end
 
   it "providing a builder and a block works" do
     stack = Faraday::RackBuilder.new do |builder|
@@ -37,6 +95,12 @@ RSpec.describe Faraday::Honeycomb::AutoInstall, auto_install: true do
       faraday.request  :url_encoded
       faraday.adapter Faraday.default_adapter
     end
-    expect(f.builder.handlers).to eq([Faraday::Honeycomb::Middleware, Faraday::Response::Logger, Faraday::Request::UrlEncoded, Faraday::Adapter::NetHttp])
+
+    expect(f.builder.handlers).to eq([
+      Faraday::Response::Logger,
+      Faraday::Request::UrlEncoded,
+      Faraday::Honeycomb::Middleware,
+      Faraday::Adapter::NetHttp
+    ])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'byebug'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`


### PR DESCRIPTION
Expands on the work done in #7 by @martin308

Some popular open source gems (e.g. octokit) cache their rack middleware
builder and reuse it across all connections. The first time this
middleware builder is used the handlers it contains will be frozen, and
can no longer be modified.

If the `AutoInstall` logic attempts to append the Honeycomb middleware
every time a connection is created then the app will error with an error
like:

```
Faraday::RackBuilder::StackLocked:
       can't modify middleware stack after making a request
```

One thing to note is that when Honeycomb's `AutoInstall` logic handles the
builder on the second connection the Honeycomb middleware is already
present in the builder, so there's no need to add it a second time.

The main change in this PR is that the `AutoInstall` logic will only
insert the middleware into the builder if it isn't already there.

Note that this will not prevent the `AutoInstall` logic erroring if a
locked middleware builder is passed to Faraday, and the Honeycomb
middleware is not present. This seems like more of an edge
case/something the developer might want to be aware of, so I'm not going
to handle it, but it should be quite easy to implement if needed.

The second major change is that the `AutoInstall` logic will always
attempt to add the middleware one level above the underlying HTTP
adapter. Some Faraday middleware (e.g. retry, follow redirects) will
cause Faraday to issue multiple HTTP requests in a single call.

In the previous code Honeycomb's middleware ran before all other
middleware, so it would miss these extra requests. By pushing the
middleware as close as possible to the adapter we should be able to
capture them.

Moving the middleware insertion logic out of the monkey patched method
allows us to collapse a lot of the if/else branches, which makes it a
lot easier to understand.

I've also tweaked the config parsing so that it handles the case where
the first argument to `Faraday.new` is a string URL.

Adding byebug/pry as a development dependency to make it easier to debug
the `AutoInstall` logic.

Fixes #6
