### PR TITLE
Do not raise error when propagating an incoming trace with context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
-script: rake && rake auto_install_spec
+script: bundle exec rake && bundle exec rake auto_install_spec
 deploy:
   provider: rubygems
   api_key:

--- a/faraday-honeycomb.gemspec
+++ b/faraday-honeycomb.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'yard'
   gem.add_development_dependency 'byebug'
   gem.add_development_dependency 'pry'
+  gem.add_development_dependency 'honeycomb-beeline'
 
   gem.files = Dir[*%w(
       lib/**/*

--- a/lib/faraday/honeycomb/middleware.rb
+++ b/lib/faraday/honeycomb/middleware.rb
@@ -114,7 +114,7 @@ module Faraday
       def add_trace_context_header(env, trace_id, span_id)
         # beeline version > 0.5.0
         if ::Honeycomb.respond_to? :encode_trace_context
-          encoded_context = ::Honeycomb.encode_trace_context(trace_id, span_id, **::Honeycomb.active_trace_context)
+          encoded_context = ::Honeycomb.encode_trace_context(trace_id, span_id, ::Honeycomb.active_trace_context)
           env.request_headers['X-Honeycomb-Trace'] = encoded_context
         end
       end

--- a/spec/middleware/middleware_spec.rb
+++ b/spec/middleware/middleware_spec.rb
@@ -1,4 +1,7 @@
 require 'faraday-honeycomb'
+# Do not require honeycomb-beeline directly as that will auto-install our faraday middleware
+require 'honeycomb/client'
+require 'honeycomb/span'
 
 require 'timeout'
 
@@ -12,6 +15,8 @@ RSpec.describe Faraday::Honeycomb::Middleware do
   end
 
   let(:fakehoney) { Libhoney::TestClient.new }
+
+  let(:propagated_header) { "" }
 
   let(:faraday) do
     Faraday.new('http://example.com') do |conn|
@@ -27,6 +32,51 @@ RSpec.describe Faraday::Honeycomb::Middleware do
     events = fakehoney.events
     expect(events.size).to eq(1)
     events[0]
+  end
+
+  describe 'outgoing trace propagation' do
+    def headers_from_outgoing_request
+      headers = nil
+
+      faraday = Faraday.new('http://example.com') do |conn|
+        conn.use :honeycomb, client: fakehoney
+        conn.adapter :test do |stub|
+          stub.get('/') {|env| headers = env.request_headers; [200, {}, 'hello'] }
+        end
+      end
+
+      faraday.get '/'
+
+      headers
+    end
+
+    context 'when executed in a request that received propagated tracing data' do
+      let(:incoming_trace_metadata) {
+        '1;trace_id=d2eb2028-193e-40e9-a2c1-fe0f12a4f2af,parent_id=8618cc79-b9b9-4e08-8804-c954d7db3b64,dataset=custom.dataset,context=eyJ3b3ciOiJzdWNoIG1ldGEifQ=='
+      }
+
+      it 'propagates a trace header containing details from the incoming HTTP request' do
+        Honeycomb.trace_from_encoded_context(incoming_trace_metadata) do
+          trace_header = headers_from_outgoing_request.fetch('X-Honeycomb-Trace')
+
+          parsed = Honeycomb.decode_trace_context(trace_header)
+
+          expect(parsed[:trace_id]).to eq("d2eb2028-193e-40e9-a2c1-fe0f12a4f2af")
+          expect(parsed[:context]).to include({"wow" => "such meta"})
+          # TODO: seems honeycomb-beeline does not support the `dataset` keyword?
+        end
+      end
+
+      it 'propagates the ID of the faraday span as the trace parent_id' do
+        Honeycomb.trace_from_encoded_context(incoming_trace_metadata) do
+          trace_header = headers_from_outgoing_request.fetch('X-Honeycomb-Trace')
+
+          parsed = Honeycomb.decode_trace_context(trace_header)
+
+          expect(parsed[:parent_span_id]).to eq(emitted_event.data['trace.span_id'])
+        end
+      end
+    end
   end
 
   describe 'after the client makes a request' do


### PR DESCRIPTION
The double splat operator only accepts hashes with symbol keys - if you
give it a hash with string keys it raises a runtime error. When the
active trace context was derived from an incoming HTTP header the keys
will contain strings, so ruby will raise a runtime error like:

```
wrong argument type String (expected Symbol)
(repl):4:in `<main>'
```

The `encode_trace_context` method only takes 3 arguments, so I'm not
sure why we need to try and turn the active trace context into keyword
arguments. The code now passes all context as a hash in the third
argument.

Unfortunately the codepath that adds the trace context header only runs
if the `honeycomb-beeline` gem is installed, so I had to add it as a
development dependency.

Fixes honeycombio/faraday-honeycomb#10